### PR TITLE
Make sure that the default internal auth code value is NOT OK.

### DIFF
--- a/mod_auth_otp.c
+++ b/mod_auth_otp.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD: mod_auth_otp
- * Copyright (c) 2015 TJ Saunders
+ * Copyright (c) 2015-2016 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -23,7 +23,7 @@
  *
  * -----DO NOT EDIT BELOW THIS LINE-----
  * $Archive: mod_auth_otp.a $
- * $Libraries: -lcrypto $
+ * $Libraries: -lcrypto$
  */
 
 #include "mod_auth_otp.h"
@@ -51,7 +51,7 @@ static int auth_otp_engine = FALSE;
 static unsigned int auth_otp_algo = AUTH_OTP_ALGO_TOTP_SHA1;
 static struct auth_otp_db *dbh = NULL;
 static config_rec *auth_otp_db_config = NULL;
-static int auth_otp_auth_code = PR_AUTH_OK;
+static int auth_otp_auth_code = PR_AUTH_BADPWD;
 
 static int handle_user_otp(pool *p, const char *user, const char *user_otp,
   int authoritative);
@@ -411,7 +411,7 @@ static int handle_user_otp(pool *p, const char *user, const char *user_otp,
  */
 
 MODRET auth_otp_auth(cmd_rec *cmd) {
-  int authoritative = FALSE, res;
+  int authoritative = FALSE, res = 0;
   char *user = NULL, *user_otp = NULL;
 
   if (auth_otp_engine == FALSE ||
@@ -456,6 +456,7 @@ MODRET auth_otp_auth(cmd_rec *cmd) {
         /* Indicate HANDLED. */
         res = 1;
       }
+
     } else {
       res = handle_user_otp(cmd->tmp_pool, user, user_otp, authoritative);
     }

--- a/t/lib/ProFTPD/Tests/Modules/mod_auth_otp/sftp.pm
+++ b/t/lib/ProFTPD/Tests/Modules/mod_auth_otp/sftp.pm
@@ -49,6 +49,12 @@ my $TESTS = {
     test_class => [qw(forking mod_auth_otp mod_sftp mod_sql mod_sql_sqlite)],
   },
 
+  # Other tests
+  auth_otp_sftp_password_failed => {
+    order => ++$order,
+    test_class => [qw(forking mod_auth_otp mod_sftp mod_sql mod_sql_sqlite)],
+  },
+
 };
 
 sub new {
@@ -1109,6 +1115,166 @@ EOS
   # Stop server
   server_stop($setup->{pid_file});
 
+  $self->assert_child_ok($pid);
+
+  test_cleanup($setup->{log_file}, $ex);
+}
+
+sub auth_otp_sftp_password_failed {
+  my $self = shift;
+  my $tmpdir = $self->{tmpdir};
+  my $setup = test_setup($tmpdir, 'auth_otp');
+
+  my $db_file = File::Spec->rel2abs("$tmpdir/proftpd.db");
+
+  # Build up sqlite3 command to create TOTP tables
+  my $db_script = File::Spec->rel2abs("$tmpdir/totp.sql");
+
+  # mod_auth_otp wants this secret to be base32-encoded, for interoperability
+  # with Google Authenticator.
+  require MIME::Base32;
+  MIME::Base32->import('RFC');
+
+  my $secret = 'Sup3rS3Cr3t';
+  my $base32_secret = MIME::Base32::encode($secret);
+  my $counter = 777;
+  my $bad_secret = 'B@d1YK3pts3kr3T!';
+
+  if (open(my $fh, "> $db_script")) {
+    print $fh <<EOS;
+CREATE TABLE auth_otp (
+  user TEXT PRIMARY KEY,
+  secret TEXT,
+  counter INTEGER
+);
+INSERT INTO auth_otp (user, secret, counter) VALUES ('$setup->{user}', '$base32_secret', $counter);
+
+EOS
+
+    unless (close($fh)) {
+      die("Can't write $db_script: $!");
+    }
+
+  } else {
+    die("Can't open $db_script: $!");
+  }
+
+  my $cmd = "sqlite3 $db_file < $db_script";
+  build_db($cmd, $db_script, $db_file);
+
+  my $rsa_host_key = File::Spec->rel2abs('t/etc/modules/mod_auth_otp/ssh_host_rsa_key');
+  my $dsa_host_key = File::Spec->rel2abs('t/etc/modules/mod_auth_otp/ssh_host_dsa_key');
+
+  my $config = {
+    PidFile => $setup->{pid_file},
+    ScoreboardFile => $setup->{scoreboard_file},
+    SystemLog => $setup->{log_file},
+    TraceLog => $setup->{log_file},
+    Trace => 'auth:20 ssh2:20 auth_otp:20',
+
+    AuthUserFile => $setup->{auth_user_file},
+    AuthGroupFile => $setup->{auth_group_file},
+    AuthOrder => 'mod_auth_file.c mod_auth_otp.c*',
+
+    IfModules => {
+      'mod_delay.c' => {
+        DelayEngine => 'off',
+      },
+
+      'mod_auth_otp.c' => {
+        AuthOTPEngine => 'on',
+        AuthOTPLog => $setup->{log_file},
+        AuthOTPAlgorithm => 'totp',
+
+        # Assumes default table names, column names
+        AuthOTPTable => 'sql:/get-user-totp/update-user-totp',
+      },
+
+      'mod_sftp.c' => [
+        "SFTPEngine on",
+        "SFTPLog $setup->{log_file}",
+        "SFTPHostKey $rsa_host_key",
+        "SFTPHostKey $dsa_host_key",
+        'SFTPAuthMethods password',
+      ],
+
+      'mod_sql.c' => [
+        'SQLEngine log',
+        'SQLBackend sqlite3',
+        "SQLConnectInfo $db_file",
+        "SQLLogFile $setup->{log_file}",
+
+        'SQLNamedQuery get-user-totp SELECT "secret, counter FROM auth_otp WHERE user = \'%{0}\'"',
+        'SQLNamedQuery update-user-totp UPDATE "counter = %{1} WHERE user = \'%{0}\'" auth_otp',
+      ],
+    },
+  };
+
+  my ($port, $config_user, $config_group) = config_write($setup->{config_file},
+    $config);
+
+  # Open pipes, for use between the parent and child processes.  Specifically,
+  # the child will indicate when it's done with its test by writing a message
+  # to the parent.
+  my ($rfh, $wfh);
+  unless (pipe($rfh, $wfh)) {
+    die("Can't open pipe: $!");
+  }
+
+  my $ex;
+
+  require Authen::OATH;
+  require Net::SSH2;
+
+  # Fork child
+  $self->handle_sigchld();
+  defined(my $pid = fork()) or die("Can't fork: $!");
+  if ($pid) {
+    eval {
+      sleep(2);
+
+      my $ssh2 = Net::SSH2->new();
+      unless ($ssh2->connect('127.0.0.1', $port)) {
+        my ($err_code, $err_name, $err_str) = $ssh2->error();
+        die("Can't connect to SSH2 server: [$err_name] ($err_code) $err_str");
+      }
+
+      # Calculate TOTP
+      my $oath = Authen::OATH->new();
+      my $totp = $oath->totp($bad_secret);
+      if ($ENV{TEST_VERBOSE}) {
+        print STDERR "# Generated TOTP $totp for current time\n";
+      }
+
+      if ($ssh2->auth_password($setup->{user}, $totp)) {
+        die("Password authentication to SSH2 server succeeded unexpectedly");
+      }
+
+      my ($err_code, $err_name, $err_str) = $ssh2->error();
+      $self->assert($err_str, qr/Authentication failed \(password\)/,
+        test_msg("Expected 'Authentication failed (password), got '$err_str'"));
+
+      $ssh2->disconnect();
+    };
+    if ($@) {
+      $ex = $@;
+    }
+
+    $wfh->print("done\n");
+    $wfh->flush();
+
+  } else {
+    eval { server_wait($setup->{config_file}, $rfh) };
+    if ($@) {
+      warn($@);
+      exit 1;
+    }
+
+    exit 0;
+  }
+
+  # Stop server
+  server_stop($setup->{pid_file});
   $self->assert_child_ok($pid);
 
   test_cleanup($setup->{log_file}, $ex);


### PR DESCRIPTION
Without this, a configuration which allowed password SSH authentication would
succeed when it shouldn't, e.g. when given a bad/mismatched password. Fixes Issue #1.
